### PR TITLE
Transfer Obligation to Resolve Confidential Identities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,19 @@
 buildscript {
     ext.corda_release_group = 'net.corda'
-    ext.corda_release_version = 'corda-3.0'
-    ext.corda_gradle_plugins_version = '3.0.9'
-    ext.kotlin_version = '1.1.60'
+    ext.corda_release_version = '4.0-SNAPSHOT-sean'
+    ext.corda_gradle_plugins_version = '4.0.28'
+    ext.kotlin_version = '1.2.51'
     ext.junit_version = '4.12'
-    ext.quasar_version = '0.7.9'
+    ext.quasar_version = '0.7.10'
+    ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
 
     repositories {
         mavenLocal()
         mavenCentral()
         jcenter()
+        maven {
+            url "$artifactory_contextUrl/corda-releases"
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,15 @@ buildscript {
     ext.kotlin_version = '1.2.51'
     ext.junit_version = '4.12'
     ext.quasar_version = '0.7.10'
+    ext.artifactory_contextUrl = 'https://ci-artifactory.corda.r3cev.com/artifactory'
 
     repositories {
         mavenLocal()
         mavenCentral()
         jcenter()
+        maven {
+            url "$artifactory_contextUrl/corda-releases"
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.corda_release_group = 'net.corda'
-    ext.corda_release_version = '4.0-SNAPSHOT'
+    ext.corda_release_version = '4.0-SNAPSHOT-sean'
     ext.corda_gradle_plugins_version = '4.0.28'
     ext.kotlin_version = '1.2.51'
     ext.junit_version = '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.corda_release_group = 'net.corda'
-    ext.corda_release_version = '4.0-SNAPSHOT-sean'
+    ext.corda_release_version = '4.0-SNAPSHOT'
     ext.corda_gradle_plugins_version = '4.0.28'
     ext.kotlin_version = '1.2.51'
     ext.junit_version = '4.12'

--- a/java-source/build.gradle
+++ b/java-source/build.gradle
@@ -5,7 +5,6 @@ repositories {
     maven { url 'https://dl.bintray.com/kotlin/exposed' }
     maven { url 'https://jitpack.io' }
     maven { url "$artifactory_contextUrl/corda-releases" }
-//    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
 }
 
 apply plugin: 'java'

--- a/java-source/build.gradle
+++ b/java-source/build.gradle
@@ -4,7 +4,8 @@ repositories {
     mavenCentral()
     maven { url 'https://dl.bintray.com/kotlin/exposed' }
     maven { url 'https://jitpack.io' }
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
+    maven { url "$artifactory_contextUrl/corda-releases" }
+//    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
 }
 
 apply plugin: 'java'

--- a/kotlin-source/build.gradle
+++ b/kotlin-source/build.gradle
@@ -4,7 +4,9 @@ repositories {
     mavenCentral()
     maven { url 'https://dl.bintray.com/kotlin/exposed' }
     maven { url 'https://jitpack.io' }
-    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
+    maven { url "$artifactory_contextUrl/corda-releases" }
+//    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
+
 }
 
 apply plugin: 'kotlin'

--- a/kotlin-source/build.gradle
+++ b/kotlin-source/build.gradle
@@ -5,7 +5,6 @@ repositories {
     maven { url 'https://dl.bintray.com/kotlin/exposed' }
     maven { url 'https://jitpack.io' }
     maven { url "$artifactory_contextUrl/corda-releases" }
-//    maven { url 'https://ci-artifactory.corda.r3cev.com/artifactory/corda-releases' }
 
 }
 

--- a/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/IdentitySyncFlowWrapper.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/IdentitySyncFlowWrapper.kt
@@ -1,0 +1,35 @@
+package net.corda.examples.obligation.flows
+
+import co.paralleluniverse.fibers.Suspendable
+import net.corda.confidential.IdentitySyncFlow
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.unwrap
+
+/**
+ * A simple wrapper of IdentitySyncFlow to make it standalone with its own flow session.
+ * It turns out to be the same as the wrapper in IdentitySyncFlowTests.
+ */
+object IdentitySyncFlowWrapper {
+    @StartableByRPC
+    @InitiatingFlow
+    class Initiator(val otherParty: Party,
+                    val tx: WireTransaction) : FlowLogic<Boolean>() {
+        @Suspendable
+        override fun call(): Boolean {
+            val otherSideSession = initiateFlow(otherParty)
+            subFlow(IdentitySyncFlow.Send(otherSideSession, tx))
+            return otherSideSession.receive<Boolean>().unwrap { it }
+        }
+    }
+
+    @InitiatedBy(Initiator::class)
+    class Receive(val otherSideSession: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            subFlow(IdentitySyncFlow.Receive(otherSideSession))
+            otherSideSession.send(true)
+        }
+    }
+}

--- a/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/IdentitySyncFlowWrapper.kt
+++ b/kotlin-source/src/main/kotlin/net/corda/examples/obligation/flows/IdentitySyncFlowWrapper.kt
@@ -5,6 +5,7 @@ import net.corda.confidential.IdentitySyncFlow
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
 import net.corda.core.transactions.WireTransaction
+import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.unwrap
 
 /**
@@ -12,14 +13,21 @@ import net.corda.core.utilities.unwrap
  * It turns out to be the same as the wrapper in IdentitySyncFlowTests.
  */
 object IdentitySyncFlowWrapper {
-    @StartableByRPC
     @InitiatingFlow
     class Initiator(val otherParty: Party,
-                    val tx: WireTransaction) : FlowLogic<Boolean>() {
+                    val tx: WireTransaction,
+                    override val progressTracker: ProgressTracker = tracker()) : FlowLogic<Boolean>() {
+        companion object {
+            object SYNCING_WRAPPER : ProgressTracker.Step("Syncing Wrapper") {
+                override fun childProgressTracker() = IdentitySyncFlow.Send.tracker()
+            }
+
+            fun tracker() = ProgressTracker(SYNCING_WRAPPER)
+        }
         @Suspendable
         override fun call(): Boolean {
             val otherSideSession = initiateFlow(otherParty)
-            subFlow(IdentitySyncFlow.Send(otherSideSession, tx))
+            subFlow(IdentitySyncFlow.Send(setOf(otherSideSession), tx, SYNCING_WRAPPER.childProgressTracker()))
             return otherSideSession.receive<Boolean>().unwrap { it }
         }
     }

--- a/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
@@ -2,8 +2,10 @@ package net.corda.examples.obligation.flows
 
 import net.corda.examples.obligation.Obligation
 import net.corda.finance.POUNDS
+import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.chooseIdentity
 import org.jgroups.util.Util.assertEquals
+import kotlin.test.assertNull
 
 class TransferObligationTests : ObligationTests() {
 
@@ -65,6 +67,33 @@ class TransferObligationTests : ObligationTests() {
         kotlin.test.assertFailsWith<IllegalStateException> {
             transferObligation(issuedObligation.linearId, a, c, anonymous = false)
         }
+    }
+
+    @org.junit.Test
+    fun `Transfer Resolves Anonymous Parties`() {
+        // Issue obligation.
+        val issuanceTransaction = issueObligation(a, b, 1000.POUNDS)
+        network.waitQuiescent()
+        val issuedObligation = issuanceTransaction.tx.outputStates.first() as Obligation
+
+        // Transfer obligation.
+        val transferTransaction = transferObligation(issuedObligation.linearId, b, c)
+        network.waitQuiescent()
+        val transferredObligation = transferTransaction.tx.outputStates.first() as Obligation
+
+        val borrowerAnonymous = transferredObligation.borrower
+        val newlenderAnoymous = transferredObligation.lender
+        // Check they are indeed anonymous
+        val borrowerAnonymousName = borrowerAnonymous.nameOrNull()
+        val newlenderAnoymousName = newlenderAnoymous.nameOrNull()
+        assertNull(borrowerAnonymousName)
+        assertNull(newlenderAnoymousName)
+
+        val newlenderDeanonymizedByBorrower = a.services.identityService.wellKnownPartyFromAnonymous(newlenderAnoymous)
+        val borrowerDeanonymizedByNewlender = c.services.identityService.wellKnownPartyFromAnonymous(borrowerAnonymous)
+        // Check anonymity is indeed resolved
+        assertEquals(a.info.singleIdentity(), borrowerDeanonymizedByNewlender)
+        assertEquals(c.info.singleIdentity(), newlenderDeanonymizedByBorrower)
     }
 
 }

--- a/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
+++ b/kotlin-source/src/test/kotlin/net/corda/examples/obligation/flows/TransferObligationTests.kt
@@ -5,6 +5,7 @@ import net.corda.finance.POUNDS
 import net.corda.testing.core.singleIdentity
 import net.corda.testing.internal.chooseIdentity
 import org.jgroups.util.Util.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class TransferObligationTests : ObligationTests() {
@@ -89,9 +90,11 @@ class TransferObligationTests : ObligationTests() {
         assertNull(borrowerAnonymousName)
         assertNull(newlenderAnoymousName)
 
+        // Check anonymity is indeed resolved
         val newlenderDeanonymizedByBorrower = a.services.identityService.wellKnownPartyFromAnonymous(newlenderAnoymous)
         val borrowerDeanonymizedByNewlender = c.services.identityService.wellKnownPartyFromAnonymous(borrowerAnonymous)
-        // Check anonymity is indeed resolved
+        assertNotNull(newlenderDeanonymizedByBorrower)
+        assertNotNull(borrowerDeanonymizedByNewlender)
         assertEquals(a.info.singleIdentity(), borrowerDeanonymizedByNewlender)
         assertEquals(c.info.singleIdentity(), newlenderDeanonymizedByBorrower)
     }


### PR DESCRIPTION
This is to resolve issue #5.
It depends on https://github.com/corda/corda/pull/3701 so the fix works only with Corda 4.0 and later.
The fix is currently only in kotlin-source. 


